### PR TITLE
Fix displaced word in FAQ

### DIFF
--- a/templates/www/devconfcz-2018-faq.html
+++ b/templates/www/devconfcz-2018-faq.html
@@ -94,7 +94,7 @@
     <div class="toggle">
       <a href="#" class="toggle-title">Can I request financial aide?<i class="fa fa-plus"></i></a>
       <div class="toggle-content">
-        <p><strong>NO</strong>. Sorry, but this is a free event. All participants will need to cover their own costs. With the only exception being that <i>accepted</i> speakers also have an option to stay at our of our preferred hotels for free for up to
+        <p><strong>NO</strong>. Sorry, but this is a free event. All participants will need to cover their own costs. With the only exception being that <em>accepted</em> speakers also have an option to stay at our of our preferred hotels for free for up to
           three nights! Booking instructions will be sent along with your accepted confirmation.</p>
       </div>
     </div>


### PR DESCRIPTION
In answer to "Can I request financial aide?" question, one word is pulled right outside of text flow. It is caused by using `<i>` to put emphasis on it. `<em>` has the same graphical effect, but not word is properly placed.