### PR TITLE
Add CentOS Dojo information to eventpage

### DIFF
--- a/templates/www/us/2019/devconfus-2019-eventpage.html
+++ b/templates/www/us/2019/devconfus-2019-eventpage.html
@@ -64,6 +64,9 @@
           <h3>{{ ('Diversity scholarships') }}:</h3>
             <p>In an effort to create a more diverse and inclusive event, we will be offering diversity scholarships that cover travel-related expenses for attendees from outside of Red Hat who are students or are relatively new or returning to full-time work in technology. As DevConf.US is the DevConf for the North America region, these scholarships will only be available to people from these locations.</p>
             <p>Details for these scholarships will be posted as soon as they are finalized.</p>
+	  <h3>{{ ('Centos Dojo') }}:</h3>
+	    <p>The CentOS and Fedora communities will be holding a Dojo on August 14th, 2019 - the day before DevConf.US begins - at Boston University, in the Balcony Room of the George Sherman Union building.</p>
+	    <p>Checkout more information about CentOS Dojo at <a href="https://wiki.centos.org/Events/Dojo/DevConfUS2019" target="_blank">Dojo at DevConf.US</a> and Dojo Call For Papers at <a href="https://docs.google.com/forms/d/e/1FAIpQLSev8wmfF-SzuUP-2PG_6tuqHy-0ePhCjHl7CybHKleas8rulg/viewform" target="_blank">CFP</a>.</p>
           <h3>{{ ('Important dates') }}:</h3>
           <ul>
             <li>{{ _('CfP Opens') }}: <b>{{ _('January 27th, 2019') }}</b></li>


### PR DESCRIPTION
Add CentOS page link to the eventpage also add the dojo CFP link to the eventpage.