### PR TITLE
Updating date in title bar of rendered page

### DIFF
--- a/templates/www/base-us.html
+++ b/templates/www/base-us.html
@@ -5,7 +5,7 @@
 {% set facebook_url = "https://www.facebook.com/DevConf.US" %}
 {% set telegram_url = "https://t.me/devconfus" %}
 
-{% set page_title = "DevConf.US | August 17-19, 2018 - Boston, USA" %}
+{% set page_title = "DevConf.US | August 15-17, 2019 - Boston, USA" %}
 
 {% set site_url = "https://devconf.us" %}
 {% set site_name = "DevConf.US" %}


### PR DESCRIPTION
Thanks to David Benoit for catching this one, I think it's the victim of too-many-tabs-open thus we rarely see the full title bar. I'll look for other places it may be incorrect.