### PR TITLE
Fix broken link to the Residence Inn hotel

### DIFF
--- a/source/us/hotels.blade.php
+++ b/source/us/hotels.blade.php
@@ -72,7 +72,7 @@
                 <h5><a href="https://www.hotelcommonwealth.com/?_vsrefdom=commonwealth-ppc&amp;gclid=Cj0KCQiA-K2MBhC-ARIsAMtLKRuGc7MUVmJ6t8RIX0MtI6m_jzGYJSIdaxDdc39ya7-pBLqyMqQrTGIaAhrOEALw_wcB&amp;gclsrc=aw.ds">Hotel Commonwealth</a>, 0.5 miles (easily accessible by T)</h5>
                 <h5><a href="https://www.reservations.com/hotel/howard-johnson-inn-fenway-park?rmcid=tophotels&amp;utm_source=googleads&amp;gclid=Cj0KCQiA-K2MBhC-ARIsAMtLKRudTil3C7M2g4uAg7j17ffUbyMpLAOVRL9D9ZnuadAj9VHPNiqQINYaAuAQEALw_wcB">The Verb Hotel</a>, 0.6 miles</h5>
                 <h5><a href="https://www.hilton.com/en/book/reservation/deeplink/?&amp;ctyhocn=BOSBBGI&amp;corporateCode=6384738&amp;flexibleDates=true">Hilton Garden Inn Boston/Brookline</a>, 1.3 miles</h5>
-                <h5><a href="<https://www.marriott.com/hotels/travel/bosfn-residence-inn-boston-back-bay-fenway/?scid=bb1a189a-fec3-4d19-a255-54ba596febe2&amp;y_source=1_MjgxODg3OC03MTUtbG9jYXRpb24uZ29vZ2xlX3dlYnNpdGVfb3ZlcnJpZGU%3D/">Residence Inn by Mariott</a>, 0.4 miles</h5>
+                <h5><a href="https://www.marriott.com/hotels/travel/bosfn-residence-inn-boston-back-bay-fenway/?scid=bb1a189a-fec3-4d19-a255-54ba596febe2&amp;y_source=1_MjgxODg3OC03MTUtbG9jYXRpb24uZ29vZ2xlX3dlYnNpdGVfb3ZlcnJpZGU%3D/">Residence Inn by Mariott</a>, 0.4 miles</h5>
                 <h5><a href="https://beaconinn.com/">Beacon Inn</a>, 0.5 miles</h5>
                 <h5><a href="https://www.hotels.com/ho749515008/?q-check-in=2021-11-10&amp;q-check-out=2021-11-11&amp;q-rooms=1&amp;q-room-0-adults=2&amp;q-room-0-children=0">Fenway Luxury Suites by Sonder</a>, 0.5 miles</h5>
                 <h5><a href="https://www.eliothotel.com/">The Elliot Hotel</a>, 0.9 miles (easily accessible by T)</h5>


### PR DESCRIPTION
The link had a redundant `<` before the http, which broke it.